### PR TITLE
Fix song directory checker

### DIFF
--- a/src/main/java/com/github/felixgail/musicbot/gplaymusic/GPlayMusicProvider.java
+++ b/src/main/java/com/github/felixgail/musicbot/gplaymusic/GPlayMusicProvider.java
@@ -146,7 +146,7 @@ public class GPlayMusicProvider extends GPlayMusicProviderBase {
         "songs/",
         new FileChooserButton(true),
         value -> {
-          File file = new File(value);
+          File file = new File(value).getAbsoluteFile();
           if (file.getParentFile() != null &&
               (file.getParentFile().exists() && (!file.exists() || (file.isDirectory() && file.listFiles().length == 0)))) {
             return null;


### PR DESCRIPTION
File.getParentFile() gets the parent path from it's current path, which can be relative.
In case of the "songs/" default path, the parent file would be null, even though the parent directory is the working directory and obviously exists.

The problem was easily fixed by first converting the file's internal path to an absolute path.